### PR TITLE
Preserve customer creation date when updating

### DIFF
--- a/script.js
+++ b/script.js
@@ -2188,15 +2188,17 @@ function saveCustomer(event) {
         }
     }
 
+    const existingCustomer = customerId ? state.customers.find(c => c.id === customerId) : null;
+
     const customerData = {
         id: customerId || `customer_${generateUUID()}`,
         name: customerName,
         email: email,
         phone: document.getElementById('customer-phone').value,
-        creation_date: new Date().toISOString(),
+        creation_date: existingCustomer?.creation_date || new Date().toISOString(),
         driving_school_details: {
             license_number: document.getElementById('customer-license').value,
-            progress_notes: customerId ? (state.customers.find(c => c.id === customerId)?.driving_school_details?.progress_notes || []) : [],
+            progress_notes: customerId ? (existingCustomer?.driving_school_details?.progress_notes || []) : [],
             lesson_credits: lessonCredits
         }
     };


### PR DESCRIPTION
## Summary
- look up the existing customer before constructing the data object
- retain the original creation timestamp when updating a customer while preserving other fields

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e022d93ce08329ab851f4ea07f309b